### PR TITLE
adjusted input field length restrictions for mqtt broker

### DIFF
--- a/src/websrc/html/PAGE_MQTT.html
+++ b/src/websrc/html/PAGE_MQTT.html
@@ -18,7 +18,7 @@
                         <div class='mb-2'>
                             <label for='server' data-i18n="p.mq.broker.n"></label>
                             <input data-r2v="serverMqtt" class='form-control' id='MqttServer' type='text'
-                                name='MqttServer' minlength="4" maxlength="60"
+                                name='MqttServer' minlength="1" maxlength="60"
                                 pattern="^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$"
                                 data-i18n="p.mq.broker.ph[placeholder];p.mq.broker.tt[title]" required>
                         </div>


### PR DESCRIPTION
Fixes issue #51 . The minimum length of the input field is now 1.