### PR TITLE
Build Script For Exporting Compile Commands

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -35,6 +35,7 @@ extra_scripts =
 	pre:tools/build/pre_build.py
 	pre:tools/build/version_update.py
 	pre:tools/webfilesbuilder/build_html.py
+    pre:tools/export_compile_commands.py
 	post:tools/build/build.py
 build_flags = 
 	-DBUILD_ENV_NAME=$PIOENV

--- a/platformio.ini
+++ b/platformio.ini
@@ -35,7 +35,7 @@ extra_scripts =
 	pre:tools/build/pre_build.py
 	pre:tools/build/version_update.py
 	pre:tools/webfilesbuilder/build_html.py
-    pre:tools/export_compile_commands.py
+	pre:tools/export_compile_commands.py
 	post:tools/build/build.py
 build_flags = 
 	-DBUILD_ENV_NAME=$PIOENV

--- a/src/version.h
+++ b/src/version.h
@@ -1,4 +1,4 @@
 // AUTO GENERATED FILE
 #ifndef VERSION
-    #define VERSION "20240707"
+    #define VERSION "20240715"
 #endif

--- a/tools/export_compile_commands.py
+++ b/tools/export_compile_commands.py
@@ -1,0 +1,10 @@
+import os
+Import("env")
+
+# include toolchain paths
+env.Replace(COMPILATIONDB_INCLUDE_TOOLCHAIN=True)
+
+# override compilation DB path
+# use this to write compile commands into build dir, but
+# I personally just want it in the base dir
+#env.Replace(COMPILATIONDB_PATH=os.path.join("$SRC_DIR", "compile_commands.json"))


### PR DESCRIPTION
I wanted to look at this in Neovim.
The clangd language server needs a compile_commands.json to function.
One can be created with `pio run -t compiledb` but it's incomplete
and doesn't include toolchain/std libraries properly without the
python script: https://docs.platformio.org/en/stable//integration/compile_commands.html

Figured it would be harmless to make a PR to help other LSP users
cloning this.