### PR TITLE
web.cpp cleanup

### DIFF
--- a/src/version.h
+++ b/src/version.h
@@ -1,4 +1,4 @@
 // AUTO GENERATED FILE
 #ifndef VERSION
-    #define VERSION "20240724"
+    #define VERSION "20240725"
 #endif

--- a/src/version.h
+++ b/src/version.h
@@ -1,4 +1,4 @@
 // AUTO GENERATED FILE
 #ifndef VERSION
-    #define VERSION "20240715"
+    #define VERSION "20240723"
 #endif

--- a/src/version.h
+++ b/src/version.h
@@ -1,4 +1,4 @@
 // AUTO GENERATED FILE
 #ifndef VERSION
-    #define VERSION "20240723"
+    #define VERSION "20240724"
 #endif

--- a/src/web.cpp
+++ b/src/web.cpp
@@ -281,8 +281,8 @@ void initWebServer()
 
     /* ----- OTA | END -----*/
 
-    const char *headerkeys[] = {"Content-Length", "Cookie"};
-    size_t headerkeyssize = sizeof(headerkeys) / sizeof(char *);
+    const char       *headerkeys[]   = {"Content-Length", "Cookie"};
+    constexpr size_t  headerkeyssize = sizeof(headerkeys) / sizeof(char *);
     serverWeb.collectHeaders(headerkeys, headerkeyssize);
     serverWeb.begin();
     LOGD("done");
@@ -1413,8 +1413,7 @@ void handleSerial()
     }
 
     doc[socketPortKey] = String(systemCfg.socketPort);
-
-    doc[zbRoleKey] = systemCfg.zbRole;
+    doc[zbRoleKey]     = systemCfg.zbRole;
 
     serializeJson(doc, result);
     serverWeb.sendHeader(respHeaderName, result);
@@ -1429,12 +1428,12 @@ void handleMqtt()
     {
         doc["enableMqtt"] = checked;
     }
-    doc["serverMqtt"] = mqttCfg.server;
-    doc["portMqtt"] = mqttCfg.port;
-    doc["userMqtt"] = mqttCfg.user;
-    doc["passMqtt"] = mqttCfg.pass;
-    doc["topicMqtt"] = mqttCfg.topic;
-    doc["intervalMqtt"] = mqttCfg.updateInt;
+    doc["serverMqtt"]    = mqttCfg.server;
+    doc["portMqtt"]      = mqttCfg.port;
+    doc["userMqtt"]      = mqttCfg.user;
+    doc["passMqtt"]      = mqttCfg.pass;
+    doc["topicMqtt"]     = mqttCfg.topic;
+    doc["intervalMqtt"]  = mqttCfg.updateInt;
     doc["mqttReconnect"] = mqttCfg.reconnectInt;
 
     if (mqttCfg.discovery)
@@ -1455,16 +1454,16 @@ void handleVpn()
     {
         doc[wgEnableKey] = checked;
     }
-    doc[wgLocalIPKey] = vpnCfg.wgLocalIP.toString();
-    doc[wgLocalSubnetKey] = vpnCfg.wgLocalSubnet.toString();
-    doc[wgLocalPortKey] = vpnCfg.wgLocalPort;
+    doc[wgLocalIPKey]      = vpnCfg.wgLocalIP.toString();
+    doc[wgLocalSubnetKey]  = vpnCfg.wgLocalSubnet.toString();
+    doc[wgLocalPortKey]    = vpnCfg.wgLocalPort;
     doc[wgLocalGatewayKey] = vpnCfg.wgLocalGateway.toString();
     doc[wgLocalPrivKeyKey] = vpnCfg.wgLocalPrivKey;
-    doc[wgEndAddrKey] = vpnCfg.wgEndAddr;
-    doc[wgEndPubKeyKey] = vpnCfg.wgEndPubKey;
-    doc[wgEndPortKey] = vpnCfg.wgEndPort;
-    doc[wgAllowedIPKey] = vpnCfg.wgAllowedIP.toString();
-    doc[wgAllowedMaskKey] = vpnCfg.wgAllowedMask.toString();
+    doc[wgEndAddrKey]      = vpnCfg.wgEndAddr;
+    doc[wgEndPubKeyKey]    = vpnCfg.wgEndPubKey;
+    doc[wgEndPortKey]      = vpnCfg.wgEndPort;
+    doc[wgAllowedIPKey]    = vpnCfg.wgAllowedIP.toString();
+    doc[wgAllowedMaskKey]  = vpnCfg.wgAllowedMask.toString();
     if (vpnCfg.wgMakeDefault)
     {
         doc[wgMakeDefaultKey] = checked;
@@ -1477,7 +1476,7 @@ void handleVpn()
     }
     doc[hnJoinCodeKey] = vpnCfg.hnJoinCode;
     doc[hnHostNameKey] = vpnCfg.hnHostName;
-    doc[hnDashUrlKey] = vpnCfg.hnDashUrl;
+    doc[hnDashUrlKey]  = vpnCfg.hnDashUrl;
 
     serializeJson(doc, result);
     serverWeb.sendHeader(respHeaderName, result);
@@ -1491,12 +1490,12 @@ String getRootData(bool update)
     String readableTime;
     getReadableTime(readableTime, vars.socketTime);
     const char *connectedSocketStatus = "connectedSocketStatus";
-    const char *connectedSocket = "connectedSocket";
-    const char *noConn = "noConn";
+    const char *connectedSocket       = "connectedSocket";
+    const char *noConn                = "noConn";
 
     doc[connectedSocketStatus] = vars.connectedClients;
-    doc[connectedSocket] = vars.socketTime;
-    doc["localTime"] = getTime();
+    doc[connectedSocket]       = vars.socketTime;
+    doc["localTime"]           = getTime();
 
     if (!update)
     {
@@ -1518,14 +1517,14 @@ String getRootData(bool update)
         doc[operationalMode] = systemCfg.workMode;
 
         doc[espUpdAvailKey] = vars.updateEspAvail;
-        doc[zbUpdAvailKey] = vars.updateZbAvail;
+        doc[zbUpdAvailKey]  = vars.updateZbAvail;
     }
 
     // ETHERNET TAB
     const char *ethConn = "ethConn";
-    const char *ethMac = "ethMac";
-    const char *ethSpd = "ethSpd";
-    const char *ethDns = "ethDns";
+    const char *ethMac  = "ethMac";
+    const char *ethSpd  = "ethSpd";
+    const char *ethDns  = "ethDns";
 
     if (networkCfg.ethEnable)
     {
@@ -1533,23 +1532,23 @@ String getRootData(bool update)
         {
             doc[ethMac] = ETH.macAddress();
         }
-        doc[ethConn] = vars.connectedEther ? 1 : 0;
+        doc[ethConn]    = vars.connectedEther ? 1 : 0;
         doc[ethDhcpKey] = networkCfg.ethDhcp ? 1 : 0;
         if (vars.connectedEther)
         {
-            doc[ethSpd] = ETH.linkSpeed();
-            doc[ethIpKey] = ETH.localIP().toString();
+            doc[ethSpd]     = ETH.linkSpeed();
+            doc[ethIpKey]   = ETH.localIP().toString();
             doc[ethMaskKey] = ETH.subnetMask().toString();
             doc[ethGateKey] = ETH.gatewayIP().toString();
-            doc[ethDns] = vars.savedEthDNS.toString(); // ETH.dnsIP().toString();
+            doc[ethDns]     = vars.savedEthDNS.toString(); // ETH.dnsIP().toString();
         }
         else
         {
-            doc[ethSpd] = noConn;
-            doc[ethIpKey] = networkCfg.ethDhcp ? noConn : ETH.localIP().toString();
+            doc[ethSpd]     = noConn;
+            doc[ethIpKey]   = networkCfg.ethDhcp ? noConn : ETH.localIP().toString();
             doc[ethMaskKey] = networkCfg.ethDhcp ? noConn : ETH.subnetMask().toString();
             doc[ethGateKey] = networkCfg.ethDhcp ? noConn : ETH.gatewayIP().toString();
-            doc[ethDns] = networkCfg.ethDhcp ? noConn : vars.savedEthDNS.toString(); // ETH.dnsIP().toString();
+            doc[ethDns]     = networkCfg.ethDhcp ? noConn : vars.savedEthDNS.toString(); // ETH.dnsIP().toString();
         }
     }
 
@@ -1566,10 +1565,10 @@ String getRootData(bool update)
 
     if (!update)
     {
-        doc["hwRev"] = hwConfig.board;
+        doc["hwRev"]    = hwConfig.board;
         doc["espModel"] = String(ESP.getChipModel());
         doc["espCores"] = ESP.getChipCores();
-        doc["espFreq"] = ESP.getCpuFreqMHz();
+        doc["espFreq"]  = ESP.getCpuFreqMHz();
 
         esp_chip_info_t chip_info;
         esp_chip_info(&chip_info);
@@ -1594,22 +1593,19 @@ String getRootData(bool update)
         else
         {
             doc["zigbeeFwRev"] = String(systemCfg.zbFw);
-            doc["zbFwSaved"] = true;
+            doc["zbFwSaved"]   = true;
         }
 
-        doc["zigbeeHwRev"] = CCTool.chip.hwRev;
-
-        doc["zigbeeIeee"] = CCTool.chip.ieee;
-
+        doc["zigbeeHwRev"]  = CCTool.chip.hwRev;
+        doc["zigbeeIeee"]   = CCTool.chip.ieee;
         doc["zigbeeFlSize"] = String(CCTool.chip.flashSize / 1024);
 
         unsigned int totalFs = LittleFS.totalBytes() / 1024;
-        unsigned int usedFs = LittleFS.usedBytes() / 1024;
-
+        unsigned int usedFs  = LittleFS.usedBytes() / 1024;
         doc["espFsSize"] = totalFs;
         doc["espFsUsed"] = usedFs;
 
-        doc[zbRoleKey] = systemCfg.zbRole;
+        doc[zbRoleKey]       = systemCfg.zbRole;
         doc["zigbeeFwSaved"] = systemCfg.zbFw;
     }
     int heapSize = ESP.getHeapSize() / 1024;
@@ -1628,7 +1624,7 @@ String getRootData(bool update)
     const char *wifiRssi = "wifiRssi";
     const char *wifiConn = "wifiConn";
     const char *wifiMode = "wifiMode";
-    const char *wifiDns = "wifiDns";
+    const char *wifiDns  = "wifiDns";
 
     if (!update)
     {
@@ -1648,15 +1644,11 @@ String getRootData(bool update)
 
                 for (int brdNewIdx = 0; brdNewIdx < BOARD_CFG_CNT; brdNewIdx++)
                 {
-                    if (brdConfigs[brdNewIdx].ethConfigIndex == brdConfigs[boardNum].ethConfigIndex)
+                    if (brdConfigs[brdNewIdx].ethConfigIndex == brdConfigs[boardNum].ethConfigIndex
+                        && brdConfigs[brdNewIdx].zbConfigIndex == brdConfigs[boardNum].zbConfigIndex
+                        && brdConfigs[brdNewIdx].mistConfigIndex == brdConfigs[boardNum].mistConfigIndex)
                     {
-                        if (brdConfigs[brdNewIdx].zbConfigIndex == brdConfigs[boardNum].zbConfigIndex)
-                        {
-                            if (brdConfigs[brdNewIdx].mistConfigIndex == brdConfigs[boardNum].mistConfigIndex)
-                            {
-                                boardArray[arrayIndex++] = brdConfigs[brdNewIdx].board;
-                            }
-                        }
+                        boardArray[arrayIndex++] = brdConfigs[brdNewIdx].board;
                     }
                 }
 
@@ -1678,27 +1670,27 @@ String getRootData(bool update)
 
     if (networkCfg.wifiEnable)
     {
-        doc[wifiMode] = 1; //"Client";
+        doc[wifiMode]    = 1; //"Client";
         doc[wifiDhcpKey] = networkCfg.wifiDhcp ? 1 : 0;
         if (WiFi.status() == WL_CONNECTED)
         { // STA connected
             doc[wifiSsidKey] = WiFi.SSID();
-            doc[wifiRssi] = WiFi.RSSI();
-            doc[wifiConn] = 1;
-            doc[wifiIpKey] = WiFi.localIP().toString();
+            doc[wifiRssi]    = WiFi.RSSI();
+            doc[wifiConn]    = 1;
+            doc[wifiIpKey]   = WiFi.localIP().toString();
             doc[wifiMaskKey] = WiFi.subnetMask().toString();
             doc[wifiGateKey] = WiFi.gatewayIP().toString();
-            doc[wifiDns] = vars.savedWifiDNS.toString(); // WiFi.dnsIP().toString();
+            doc[wifiDns]     = vars.savedWifiDNS.toString(); // WiFi.dnsIP().toString();
         }
         else
         {
             doc[wifiSsidKey] = networkCfg.wifiSsid;
-            doc[wifiRssi] = noConn;
-            doc[wifiConn] = 0;
-            doc[wifiIpKey] = networkCfg.wifiDhcp ? noConn : WiFi.localIP().toString();
+            doc[wifiRssi]    = noConn;
+            doc[wifiConn]    = 0;
+            doc[wifiIpKey]   = networkCfg.wifiDhcp ? noConn : WiFi.localIP().toString();
             doc[wifiMaskKey] = networkCfg.wifiDhcp ? noConn : WiFi.subnetMask().toString();
             doc[wifiGateKey] = networkCfg.wifiDhcp ? noConn : WiFi.gatewayIP().toString();
-            doc[wifiDns] = networkCfg.wifiDhcp ? noConn : vars.savedWifiDNS.toString(); // WiFi.dnsIP().toString();
+            doc[wifiDns]     = networkCfg.wifiDhcp ? noConn : vars.savedWifiDNS.toString(); // WiFi.dnsIP().toString();
         }
     }
 
@@ -1706,57 +1698,53 @@ String getRootData(bool update)
     { // AP active
         String AP_NameString;
 
-        doc[wifiMode] = 2;
-        doc[wifiConn] = 1;
+        doc[wifiMode]    = 2;
+        doc[wifiConn]    = 1;
         doc[wifiSsidKey] = vars.deviceId;
-        doc[wifiIpKey] = WiFi.localIP().toString(); //"192.168.1.1 (XZG web interface)";
+        doc[wifiIpKey  ] = WiFi.localIP().toString(); //"192.168.1.1 (XZG web interface)";
         doc[wifiMaskKey] = "255.255.255.0 (Access point)";
         doc[wifiGateKey] = "192.168.1.1 (this device)";
         doc[wifiDhcpKey] = "On (Access point)";
-        doc[wifiMode] = 2;      //"AP";
-        doc[wifiRssi] = noConn; //"N/A";
+        doc[wifiMode]    = 2;      //"AP";
+        doc[wifiRssi]    = noConn; //"N/A";
     }
 
     // MQTT
     if (mqttCfg.enable)
     {
         const char *mqConnect = "mqConnect";
-        const char *mqBroker = "mqBroker";
+        const char *mqBroker  = "mqBroker";
 
-        doc[mqBroker] = mqttCfg.server;
-
+        doc[mqBroker]  = mqttCfg.server;
         doc[mqConnect] = vars.mqttConn ? 1 : 0;
     }
 
     // VPN WireGuard
     if (vpnCfg.wgEnable)
     {
-        const char *wgInit = "wgInit";
+        const char *wgInit       = "wgInit";
         const char *wgDeviceAddr = "wgDeviceAddr";
         const char *wgRemoteAddr = "wgRemoteAddr";
-        const char *wgConnect = "wgConnect";
-        const char *wgRemoteIP = "wgRemoteIp";
+        const char *wgConnect    = "wgConnect";
+        const char *wgRemoteIP   = "wgRemoteIp";
         // const char *wgEndPort = "wgEndPort";
 
-        doc[wgInit] = vars.vpnWgInit ? 1 : 0;
+        doc[wgInit]       = vars.vpnWgInit ? 1 : 0;
         doc[wgDeviceAddr] = vpnCfg.wgLocalIP.toString();
         doc[wgRemoteAddr] = vpnCfg.wgEndAddr;
+        doc[wgConnect]    = vars.vpnWgConnect ? 1 : 0;
+        doc[wgRemoteIP]   = vars.vpnWgPeerIp.toString();
         // doc[wgEndPort] = vpnCfg.wgEndPort;
-
-        doc[wgConnect] = vars.vpnWgConnect ? 1 : 0;
-
-        doc[wgRemoteIP] = vars.vpnWgPeerIp.toString();
     }
     // VPN Husarnet
     if (vpnCfg.hnEnable)
     {
-        const char *hnInit = "hnInit";
+        const char *hnInit     = "hnInit";
         const char *hnHostName = "hnHostName";
 
         // doc[wgDeviceAddr] = vpnCfg.wgLocalIP.toString();//WgSettings.localAddr;
         doc[hnHostName] = vpnCfg.hnHostName;
-
-        doc[hnInit] = vars.vpnHnInit ? 1 : 0;
+        doc[hnInit]     = vars.vpnHnInit ? 1 : 0;
     }
 
     String result;
@@ -1776,12 +1764,12 @@ void handleTools()
     String result;
     DynamicJsonDocument doc(512);
 
-    doc[hwBtnIsKey] = vars.hwBtnIs;
-    // doc[hwUartSelIsKey] = vars.hwUartSelIs;
+    doc[hwBtnIsKey]    = vars.hwBtnIs;
     doc[hwLedPwrIsKey] = vars.hwLedPwrIs;
     doc[hwLedUsbIsKey] = vars.hwLedUsbIs;
-    // doc["hostname"] = systemCfg.hostname;
-    // doc["refreshLogs"] = systemCfg.refreshLogs;
+    // doc[hwUartSelIsKey] = vars.hwUartSelIs;
+    // doc["hostname"]     = systemCfg.hostname;
+    // doc["refreshLogs"]  = systemCfg.refreshLogs;
 
     serializeJson(doc, result);
     serverWeb.sendHeader(respHeaderName, result);
@@ -1798,8 +1786,9 @@ void handleSavefile()
     else
     {
         String filename = "/" + serverWeb.arg(0);
-        String content = serverWeb.arg(1);
-        File file = LittleFS.open(filename, "w");
+        String content  = serverWeb.arg(1);
+        File   file     = LittleFS.open(filename, "w");
+
         LOGD("try %s", filename.c_str());
 
         if (!file)
@@ -1807,7 +1796,6 @@ void handleSavefile()
             LOGW("Failed to open file for reading");
             return;
         }
-
         int bytesWritten = file.print(content);
         if (bytesWritten > 0)
         {
@@ -1827,7 +1815,6 @@ void handleSavefile()
 /* ----- Multi-tool support | START -----*/
 void handleZigbeeBSL()
 {
-
     zigbeeEnableBSL();
     serverWeb.send(HTTP_CODE_OK, contTypeText, "Zigbee BSL");
 }
@@ -1887,7 +1874,6 @@ void progressNvRamFunc(unsigned int progress, unsigned int total)
 */
 void progressFunc(unsigned int progress, unsigned int total)
 {
-
     const uint8_t eventLen = 11;
 
     float percent = ((float)progress / total) * 100.0;

--- a/src/web.cpp
+++ b/src/web.cpp
@@ -98,7 +98,7 @@ const char *apiWrongArgs       = "wrong args";
 const char *apiOk              = "ok";
 const char *errLink            = "Error getting link";
 
-// MIME types and misc stuff
+// MIME types
 const char *contTypeTextHtml   = "text/html";
 const char *contTypeTextJs     = "text/javascript";
 const char *contTypeTextCss    = "text/css";
@@ -338,18 +338,25 @@ void handleNotFound()
 
     for (uint8_t i = 0; i < serverWeb.args(); i++)
     {
-        message += String(F(" ")) + serverWeb.argName(i) + F(": ") + serverWeb.arg(i) + F("\n");
+        message += String(F(" "))
+                   + serverWeb.argName(i)
+                   + F(": ")
+                   + serverWeb.arg(i)
+                   + F("\n");
     }
-    serverWeb.sendHeader("Cache-Control", "no-cache, no-store, must-revalidate");
-    serverWeb.sendHeader("Pragma", "no-cache");
-    serverWeb.sendHeader("Expires", "-1");
-    serverWeb.send(404, "text/plain", message);
+    serverWeb.sendHeader ("Cache-Control", "no-cache, no-store, must-revalidate");
+    serverWeb.sendHeader ("Pragma", "no-cache");
+    serverWeb.sendHeader ("Expires", "-1");
+    serverWeb.send       (404, "text/plain", message);
 }
 
 void handleUpdateRequest()
 {
-    serverWeb.sendHeader("Connection", "close");
-    serverWeb.send(HTTP_CODE_OK, contTypeText, "Upload OK. Try to flash...");
+    serverWeb.sendHeader ("Connection",
+                          "close");
+    serverWeb.send       (HTTP_CODE_OK,
+                          contTypeText,
+                          "Upload OK. Try to flash...");
 }
 
 void handleEspUpdateUpload()
@@ -363,11 +370,16 @@ void handleEspUpdateUpload()
     static long contentLength = 0;
     if (upload.status == UPLOAD_FILE_START)
     {
-        LOGD("hostHeader: %s", serverWeb.hostHeader());
         contentLength = serverWeb.header("Content-Length").toInt();
-        LOGD("contentLength: %s", String(contentLength));
-        LOGD("Update ESP from file %s size: %s", String(upload.filename.c_str()), String(upload.totalSize));
-        LOGD("upload.currentSize %s", String(upload.currentSize));
+        LOGD ("hostHeader: %s",
+              serverWeb.hostHeader());
+        LOGD ("contentLength: %s",
+              String(contentLength));
+        LOGD ("Update ESP from file %s size: %s",
+              String(upload.filename.c_str()),
+              String(upload.totalSize));
+        LOGD ("upload.currentSize %s",
+              String(upload.currentSize));
         if (!Update.begin(contentLength))
         {
             Update.printError(Serial);
@@ -407,18 +419,20 @@ void handleEvents()
         eventsClient = serverWeb.client();
         if (eventsClient)
         {
-            eventsClient.println("HTTP/1.1 200 OK");
-            eventsClient.println("Content-Type: text/event-stream;");
-            eventsClient.println("Connection: close");
-            eventsClient.println("Access-Control-Allow-Origin: *");
-            eventsClient.println("Cache-Control: no-cache");
-            eventsClient.println();
-            eventsClient.flush();
+            eventsClient.println ("HTTP/1.1 200 OK");
+            eventsClient.println ("Content-Type: text/event-stream;");
+            eventsClient.println ("Connection: close");
+            eventsClient.println ("Access-Control-Allow-Origin: *");
+            eventsClient.println ("Cache-Control: no-cache");
+            eventsClient.println ();
+            eventsClient.flush   ();
         }
     }
 }
 
-void sendEvent(const char *event, const uint8_t evsz, const String data)
+void sendEvent(const char *event,
+               const uint8_t evsz,
+               const String data)
 {
     if (eventsClient)
     {
@@ -430,10 +444,16 @@ void sendEvent(const char *event, const uint8_t evsz, const String data)
     }
 }
 
-void sendGzip(const char *contentType, const uint8_t content[], uint16_t contentLen)
+void sendGzip(const char *contentType,
+              const uint8_t content[],
+              uint16_t contentLen)
 {
-    serverWeb.sendHeader(F("Content-Encoding"), F("gzip"));
-    serverWeb.send_P(HTTP_CODE_OK, contentType, (const char *)content, contentLen);
+    serverWeb.sendHeader (F("Content-Encoding"),
+                          F("gzip"));
+    serverWeb.send_P     (HTTP_CODE_OK,
+                          contentType,
+                          (const char *)content,
+                          contentLen);
 }
 
 // This isn't called from anywhere,
@@ -471,7 +491,9 @@ static void apiGetLog()
 static void apiCmdUpdateUrl(String &result)
 {
     if (serverWeb.hasArg(argUrl))
+    {
         getEspUpdate(serverWeb.arg(argUrl));
+    }
     else
     {
         String link = fetchLatestEspFw();
@@ -513,6 +535,7 @@ static void apiCmdZbLedToggle(String &result)
 static void apiCmdFactoryReset(String &result)
 {
     if (serverWeb.hasArg(argConf))
+    {
         if (serverWeb.arg(argConf).toInt() == 1)
         {
             serverWeb.send(HTTP_CODE_OK, contTypeText, result);
@@ -522,6 +545,7 @@ static void apiCmdFactoryReset(String &result)
         {
             serverWeb.send(HTTP_CODE_BAD_REQUEST, contTypeText, result);
         }
+    }
 }
 
 static void apiCmdLedAct(String &result)
@@ -531,7 +555,7 @@ static void apiCmdLedAct(String &result)
         int ledNum = serverWeb.arg(argLed).toInt();
         int actNum = serverWeb.arg(argAct).toInt();
 
-        LED_t ledEnum = static_cast<LED_t>(ledNum);
+        LED_t   ledEnum = static_cast<LED_t>(ledNum);
         LEDMode actEnum = static_cast<LEDMode>(actNum);
 
         if (static_cast<int>(ledEnum) == ledNum && static_cast<int>(actEnum) == actNum)
@@ -563,9 +587,10 @@ static void apiCmdLedAct(String &result)
 static void apiCmdZbFlash(String &result)
 {
     if (serverWeb.hasArg(argUrl))
-        flashZbUrl(serverWeb.arg(argUrl));
-    else
     {
+        flashZbUrl(serverWeb.arg(argUrl));
+    }
+    else {
         String link = fetchLatestZbFw();
         if (link)
         {
@@ -672,7 +697,8 @@ static void apiCmdDnsCheck(String &result)
 
 static void apiCmd()
 {
-    static void (*apiCmdFunctions[])(String &result) = {
+    static void (*apiCmdFunctions[])(String &result) =
+    {
         apiCmdDefault,
         apiCmdZbRouterRecon,
         apiCmdZbRestart,
@@ -704,9 +730,9 @@ static void apiCmd()
         // but then I'd need to modify this in ALL of the client code...
         uint8_t command     = serverWeb.arg(argCmd).toInt() + 1;
         bool    boundsCheck = command < numFunctions;
-        {
-            apiCmdFunctions[command * boundsCheck](result);
-        }
+
+        apiCmdFunctions[command * boundsCheck](result);
+
         serverWeb.send(HTTP_CODE_OK, contTypeText, result);
     }
 
@@ -720,7 +746,7 @@ static void apiWifiConnnectStat()
     if (WiFi.status() == WL_CONNECTED)
     {
         doc[connected] = true;
-        doc["ip"] = WiFi.localIP().toString();
+        doc["ip"]      = WiFi.localIP().toString();
     }
     else
     {
@@ -739,10 +765,11 @@ static void apiGetFile()
         String filename = "/" + serverWeb.arg(argFilename);
         File file = LittleFS.open(filename, "r");
         if (!file)
-            return;
-        result = "";
-        while (file.available() && result.length() < 500)
         {
+            return;
+        }
+        result = "";
+        while (file.available() && result.length() < 500) {
             result += (char)file.read();
         }
         file.close();
@@ -834,11 +861,12 @@ static void apiStartWifiScan()
 
 static void apiWifiScanStatus()
 {
-    static uint8_t timeout = 0;
-    DynamicJsonDocument doc(1024);
-    String result = "";
-    int16_t scanRes = WiFi.scanComplete();
-    const char *scanDone = "scanDone";
+    static uint8_t       timeout  = 0;
+    DynamicJsonDocument  doc(1024);
+    String               result   = "";
+    int16_t              scanRes  = WiFi.scanComplete();
+    const char          *scanDone = "scanDone";
+
     doc[scanDone] = false;
     if (scanRes == -2)
     {
@@ -851,10 +879,10 @@ static void apiWifiScanStatus()
         for (int i = 0; i < scanRes; ++i)
         {
             JsonObject wifi_0 = wifi.createNestedObject();
-            wifi_0["ssid"] = WiFi.SSID(i);
-            wifi_0["rssi"] = WiFi.RSSI(i);
+            wifi_0["ssid"]    = WiFi.SSID(i);
+            wifi_0["rssi"]    = WiFi.RSSI(i);
             wifi_0["channel"] = WiFi.channel(i);
-            wifi_0["secure"] = WiFi.encryptionType(i);
+            wifi_0["secure"]  = WiFi.encryptionType(i);
         }
         WiFi.scanDelete();
     }

--- a/src/web.cpp
+++ b/src/web.cpp
@@ -10,9 +10,7 @@
 #include <WiFi.h>
 #include <Ticker.h>
 #include <CCTools.h>
-#include <memory>
 
-#include "ArduinoJson/Document/DynamicJsonDocument.hpp"
 #include "config.h"
 #include "web.h"
 #include "log.h"


### PR DESCRIPTION
Just a little janitorial work, I simply like to clean as I read.

I did the following:
- Broke up some massive 200-400 line functions into smaller ones.
- Replaced some switches+enums with branchless function arrays for speed and readability.
- Binary size is SLIGHTLY smaller.

I can undo the weird indentation stuff if you don't like it,
but C++ Core Guidelines encourage liberal use of whitespace for
legibility.

C++ code is still very C-like, could make it more "idiomatic",
but I'm happy with it.
Tested it on our hardware and still seems to do what it should when I click around!
Please double check function arrays (for off-by 1 or wrong indices), and getRootData() - I reordered a lot of code.

If these kind of changes are welcome, I'm happy to do some more.