### PR TITLE
Default Hostnames Derived From MAC

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -220,7 +220,6 @@ void loadVpnConfig(VpnConfigStruct &config)
 
     config.hnEnable = preferences.getBool(hnEnableKey, false);
     strlcpy(config.hnJoinCode, preferences.getString(hnJoinCodeKey).c_str(), sizeof(config.hnJoinCode));
-    strlcpy(config.hnHostName, preferences.getString(hnHostNameKey, String(vars.deviceId)).c_str(), sizeof(config.hnHostName));
     strlcpy(config.hnDashUrl, preferences.getString(hnDashUrlKey, "default").c_str(), sizeof(config.hnDashUrl));
 
     preferences.end();
@@ -330,7 +329,6 @@ void loadMqttConfig(MqttConfigStruct &config)
     config.port = preferences.getInt(portKey, 1883);
     strlcpy(config.user, preferences.getString(userKey, "").c_str(), sizeof(config.user));
     strlcpy(config.pass, preferences.getString(passKey, "").c_str(), sizeof(config.pass));
-    strlcpy(config.topic, preferences.getString(topicKey, String(vars.deviceId)).c_str(), sizeof(config.topic));
     // config.retain = preferences.getBool(retain, false); // If needed
     config.updateInt = preferences.getInt(updateIntKey, 60);
     config.discovery = preferences.getBool(discoveryKey, true);
@@ -378,6 +376,7 @@ void saveSystemConfig(const SystemConfigStruct &config)
     preferences.end();
 }
 
+
 void loadSystemConfig(SystemConfigStruct &config)
 {
     preferences.begin(systemConfigKey, true);
@@ -396,7 +395,6 @@ void loadSystemConfig(SystemConfigStruct &config)
     config.disableLedUSB = preferences.getBool(disableLedUSBKey, false);
     config.disableLedPwr = preferences.getBool(disableLedPwrKey, false);
     config.refreshLogs = preferences.getInt(refreshLogsKey, 2);
-    strlcpy(config.hostname, preferences.getString(hostnameKey, "XZG").c_str(), sizeof(config.hostname)); /// to do add def host name!!
     strlcpy(config.timeZone, preferences.getString(timeZoneKey, NTP_TIME_ZONE).c_str(), sizeof(config.timeZone));
     strlcpy(config.ntpServ1, preferences.getString(ntpServ1Key, NTP_SERV_1).c_str(), sizeof(config.ntpServ1));
     strlcpy(config.ntpServ2, preferences.getString(ntpServ2Key, NTP_SERV_2).c_str(), sizeof(config.ntpServ2));
@@ -416,6 +414,20 @@ void loadSystemConfig(SystemConfigStruct &config)
     config.updAutoInst = preferences.getBool(updAutoInstKey, false);
 
     preferences.end();
+}
+
+void writeDeviceId(SystemConfigStruct &sysConfig, VpnConfigStruct &vpnConfig, MqttConfigStruct &mqttConfig)
+{
+    preferences.begin(systemConfigKey, true);
+    strlcpy(sysConfig.hostname, preferences.getString(hostnameKey, String(vars.deviceId)).c_str(), sizeof(sysConfig.hostname));
+    preferences.end();
+    preferences.begin(vpnConfigKey, true);
+    strlcpy(vpnConfig.hnHostName, preferences.getString(hnHostNameKey, String(vars.deviceId)).c_str(), sizeof(vpnConfig.hnHostName));
+    preferences.end();
+    preferences.begin(mqttConfigKey, true);
+    strlcpy(mqttConfig.topic, preferences.getString(topicKey, String(vars.deviceId)).c_str(), sizeof(mqttConfig.topic));
+    preferences.end();
+    LOGD("Sysconfig hostname: %s", sysConfig.hostname);
 }
 
 /*

--- a/src/config.h
+++ b/src/config.h
@@ -278,6 +278,8 @@ bool loadFileConfigHW();
 void saveHwConfig(const ThisConfigStruct &config);
 void loadHwConfig(ThisConfigStruct &config);
 
+void writeDeviceId(SystemConfigStruct &sysConfig, VpnConfigStruct &vpnConfig, MqttConfigStruct &mqttConfig);
+
 /* Previous firmware read config support. start */
 /*
 bool loadFileSystemVar();

--- a/src/etc.cpp
+++ b/src/etc.cpp
@@ -320,37 +320,26 @@ void usbModeSet(usbMode mode)
   //}
 }
 
-void getDeviceID(char *arr)
+void writeDefaultDeviceId(char *arr, bool ethernet)
 {
-  uint64_t mac = ESP.getEfuseMac(); // Retrieve the MAC address
-  uint8_t a = 0;                    // Initialize variables to store the results
-  uint8_t b = 0;
+    char id_str[MAX_DEV_ID_LONG] = "XZG-";
+    const size_t id_str_len = strlen(id_str);
+    union MacAddress {
+        uint8_t bytes[8];
+        uint64_t value;
+    } mac = {};
 
-  // Apply XOR operation to each byte of the MAC address to obtain unique values for a and b
-  a ^= (mac >> (8 * 0)) & 0xFF;
-  a ^= (mac >> (8 * 1)) & 0xFF;
-  a ^= (mac >> (8 * 2)) & 0xFF;
-  a ^= (mac >> (8 * 3)) & 0xFF;
-  b ^= (mac >> (8 * 4)) & 0xFF;
-  b ^= (mac >> (8 * 5)) & 0xFF;
-
-  char buf[MAX_DEV_ID_LONG];
-
-  // Format a and b into buf as hexadecimal values, ensuring two-digit representation for each
-  sprintf(buf, "%02x%02x", a, b);
-
-  // Convert each character in buf to upper case
-  for (uint8_t cnt = 0; buf[cnt] != '\0'; cnt++)
-  {
-    buf[cnt] = toupper(buf[cnt]);
-  }
-
-  // Form the final string including the board name and the processed MAC address
-
-  // sprintf(arr, "%s-%s", hwConfig.board, buf);
-
-  String devicePref = "XZG"; // hwConfig.board
-  snprintf(arr, MAX_DEV_ID_LONG + 1, "%s-%s", devicePref.c_str(), buf);
+    if (ethernet) {
+        ETH.macAddress(mac.bytes);
+    }
+    else {
+        mac.value = ESP.getEfuseMac();
+    }
+    snprintf(&id_str[id_str_len],
+             MAX_DEV_ID_LONG - id_str_len,
+             "%02X%02X",
+             mac.bytes[4], mac.bytes[5]);
+    memcpy(arr, id_str, MAX_DEV_ID_LONG);
 }
 
 /*void writeDefaultConfig(const char *path, DynamicJsonDocument &doc)

--- a/src/etc.h
+++ b/src/etc.h
@@ -26,7 +26,7 @@ void zigbeeRestart();
 
 void usbModeSet(usbMode mode);
 
-void getDeviceID(char *arr);
+void writeDefaultDeviceId(char *arr, bool ethernet);
 //void writeDefaultConfig(const char *path, DynamicJsonDocument &doc);
 
 #define TIMEOUT_FACTORY_RESET 3

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -604,12 +604,19 @@ void networkStart()
     tmrNetworkOverseer.attach(overseerInterval, handleTmrNetworkOverseer);
   }
   WiFi.onEvent(NetworkEvent);
-  if (networkCfg.ethEnable)
+  if (networkCfg.ethEnable){
     initLan();
+    writeDefaultDeviceId (vars.deviceId, true); // need for mqtt, vpn, mdns, wifi ap and so on
+  }
+  else {
+    writeDefaultDeviceId (vars.deviceId, false); // need for mqtt, vpn, mdns, wifi ap and so on
+  }
+
   if (networkCfg.wifiEnable)
     connectWifi();
+ 
+  writeDeviceId        (systemCfg, vpnCfg, mqttCfg);
   //}
-
   // if (!systemCfg.disableWeb && ((systemCfg.workMode != WORK_MODE_USB) || systemCfg.keepWeb))
   //   updWeb = true; // handle web server
   if (!systemCfg.disableWeb)
@@ -709,8 +716,6 @@ void setup()
 
   initNVS();
 
-  getDeviceID(vars.deviceId); // need for mqtt, vpn, mdns, wifi ap and so on
-
   loadSystemConfig(systemCfg);
   loadNetworkConfig(networkCfg);
   loadVpnConfig(vpnCfg);
@@ -783,6 +788,7 @@ void setup()
   vars.apStarted = false;
 
   networkStart();
+
 
   /*while (WiFi.status() != WL_CONNECTED && !vars.connectedEther)
   {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -606,16 +606,10 @@ void networkStart()
   WiFi.onEvent(NetworkEvent);
   if (networkCfg.ethEnable){
     initLan();
-    writeDefaultDeviceId (vars.deviceId, true); // need for mqtt, vpn, mdns, wifi ap and so on
   }
-  else {
-    writeDefaultDeviceId (vars.deviceId, false); // need for mqtt, vpn, mdns, wifi ap and so on
-  }
-
   if (networkCfg.wifiEnable)
     connectWifi();
- 
-  writeDeviceId        (systemCfg, vpnCfg, mqttCfg);
+
   //}
   // if (!systemCfg.disableWeb && ((systemCfg.workMode != WORK_MODE_USB) || systemCfg.keepWeb))
   //   updWeb = true; // handle web server
@@ -788,6 +782,9 @@ void setup()
   vars.apStarted = false;
 
   networkStart();
+
+  writeDefaultDeviceId(vars.deviceId, networkCfg.ethEnable); // need for mqtt, vpn, mdns, wifi ap and so on
+  writeDeviceId(systemCfg, vpnCfg, mqttCfg);
 
 
   /*while (WiFi.status() != WL_CONNECTED && !vars.connectedEther)

--- a/src/version.h
+++ b/src/version.h
@@ -1,4 +1,4 @@
 // AUTO GENERATED FILE
 #ifndef VERSION
-    #define VERSION "20241001"
+    #define VERSION "20241207"
 #endif


### PR DESCRIPTION
Default mqtt topic, vpn hostname and system hostname are now in the form "XZG-XXXX" where XXXX are
the last 4 upper case hexadecimal digits of the ethernet/wifi MAC address.

This specific configuration was unique in that it needed to be deferred until after Ethernet is initialized
(Efuse MAC is available without initialization).