### PR TITLE
Support for Zigbee2MQTT 2.0

### DIFF
--- a/src/websrc/js/functions.js
+++ b/src/websrc/js/functions.js
@@ -294,6 +294,7 @@ advanced:
 			result = `# ${i18next.t('p.zi.cfg.ss')}
 serial:
 # ${i18next.t('p.zi.cfg.lxzg')}
+  adapter: zstack
   port: tcp://${ip}:${port}
   ${mist_cfg_txt}`;
 			break;


### PR DESCRIPTION
Added the `adapter: zstack` parameter to the Configuration generator to ensure compatibility with Zigbee2MQTT versions 2.0 and above, as these newer versions require this setting to function properly (`adapter: auto` was removed).