### PR TITLE
Added #defines to customise/disable fs auto update

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -663,6 +663,13 @@ void timerCallback(TimerHandle_t xTimer)
   xTaskCreate(getEspUpdateTask, "getEspUpdateTask", 8192, params, 1, NULL);
 }
 
+// Define this in the build system to
+// disable file system auto update
+#ifdef DISABLE_FS_AUTO_UPDATE
+void checkFileSys()
+{
+}
+#else
 void checkFileSys()
 {
   FirmwareInfo fwInfo = fetchLatestEspFw("fs");
@@ -701,6 +708,7 @@ void checkFileSys()
     }
   }
 }
+#endif
 
 void setup()
 {

--- a/src/version.h
+++ b/src/version.h
@@ -1,4 +1,4 @@
 // AUTO GENERATED FILE
 #ifndef VERSION
-    #define VERSION "20241207"
+    #define VERSION "20250310"
 #endif

--- a/src/web.cpp
+++ b/src/web.cpp
@@ -19,6 +19,22 @@
 #include "zb.h"
 #include "const/zones.h"
 #include "const/keys.h"
+
+// These are all of the URLs used
+// by the backend.
+// Redefine these here, or in build system if necessary.
+#ifndef BACKEND_CUSTOM_URLS
+#define FW_UPDATE_URL_BASE "https://github.com/xyzroe/XZG/releases/download/"
+#define FW_UPDATE_URL_RELEASE_NAME "XZG_"
+#define FW_UPDATE_RELEASE_MANIFEST_URL "https://raw.githubusercontent.com/xyzroe/XZG/refs/heads/releases/latest/xzg.json"
+#define ZB_UPDATE_RELEASE_MANIFEST_URL "https://raw.githubusercontent.com/xyzroe/XZG/zb_fws/ti/manifest.json"
+#endif
+
+static const char *fw_update_url_base = FW_UPDATE_URL_BASE;
+static const char *fw_update_url_release_name = FW_UPDATE_URL_RELEASE_NAME;
+static const char *fw_update_release_manifest_url = FW_UPDATE_RELEASE_MANIFEST_URL;
+static const char *zb_update_release_manifest_url = ZB_UPDATE_RELEASE_MANIFEST_URL;
+
 // #include "const/hw.h"
 
 /*
@@ -2219,7 +2235,7 @@ FirmwareInfo fetchLatestEspFw(String type)
     {
         HTTPClient http;
         http.setFollowRedirects(HTTPC_STRICT_FOLLOW_REDIRECTS);
-        http.begin("https://raw.githubusercontent.com/xyzroe/XZG/refs/heads/releases/latest/xzg.json");
+        http.begin(fw_update_release_manifest_url);
         int httpCode = http.GET();
 
         if (httpCode > 0)
@@ -2239,7 +2255,11 @@ FirmwareInfo fetchLatestEspFw(String type)
                 if (release.containsKey("version"))
                 {
                     info.version = release["version"].as<String>();
-                    info.url = "https://github.com/xyzroe/XZG/releases/download/" + info.version + "/XZG_" + info.version + "." + type + ".bin";
+                    info.url = fw_update_url_base
+                               + info.version
+                               + "/"
+                               + fw_update_url_release_name
+                               + info.version + "." + type + ".bin";
                     //info.url = "https://raw.githubusercontent.com/xyzroe/XZG/refs/heads/releases/latest/XZG." + type + ".bin";
                     LOGD("Latest version: %s | url %s", info.version.c_str(), info.url.c_str());
                 }
@@ -2288,7 +2308,7 @@ String fetchLatestZbFw()
 {
     // checkDNS();
     HTTPClient http;
-    http.begin("https://raw.githubusercontent.com/xyzroe/XZG/zb_fws/ti/manifest.json");
+    http.begin(zb_update_release_manifest_url);
     int httpCode = http.GET();
 
     String browser_download_url = "";


### PR DESCRIPTION
I discovered that the backend has hardcoded github update urls,
so I've added some defines to be able to easily change them in a custom build.