### PR TITLE
feat: add support for SmartAll ZgbMix (zgw_poe_v1.3) board

### DIFF
--- a/src/const/hw.cpp
+++ b/src/const/hw.cpp
@@ -6,6 +6,7 @@ EthConfig ethConfigs[] = {
     {.addr = 0, .pwrPin = 12, .mdcPin = 23, .mdiPin = 18, .phyType = ETH_PHY_LAN8720, .clkMode = ETH_CLOCK_GPIO17_OUT}, // .pwrAltPin = -1},  // 0 Olimex-ESP32-POE
     {.addr = 1, .pwrPin = 16, .mdcPin = 23, .mdiPin = 18, .phyType = ETH_PHY_LAN8720, .clkMode = ETH_CLOCK_GPIO0_IN},   // .pwrAltPin = -1},  // 1 WT32-ETH01 / SLZB-06
     {.addr = 0, .pwrPin = 5, .mdcPin = 23, .mdiPin = 18, .phyType = ETH_PHY_LAN8720, .clkMode = ETH_CLOCK_GPIO17_OUT},  // .pwrAltPin = -1},  // 2 T-Internet-POE / UZG-01 / HamGeek POE Plus / WGNETZG
+    {.addr = 0, .pwrPin = 2, .mdcPin = 23, .mdiPin = 18, .phyType = ETH_PHY_LAN8720, .clkMode = ETH_CLOCK_GPIO0_IN},    // .pwrAltPin = -1},  // 3 SmartAll ZgbMix
 };
 
 // ZigBee configurations
@@ -19,6 +20,7 @@ ZbConfig zbConfigs[] = {
     {.txPin = 16, .rxPin = 5, .rstPin = 13, .bslPin = 4},   // 5 TubesZB-poe-2022
     {.txPin = 4, .rxPin = 36, .rstPin = 5, .bslPin = 16},   // 6 TubesZB-poe-2023
     {.txPin = 23, .rxPin = 22, .rstPin = 18, .bslPin = 19}, // 7 SLS-classic
+    {.txPin = 33, .rxPin = 32, .rstPin = 15, .bslPin = 5},  // 8 SmartAll ZgbMix
 };
 
 // Mist configurations
@@ -29,6 +31,7 @@ MistConfig mistConfigs[] = {
     {.btnPin = 35, .btnPlr = 1, .uartSelPin = 4, .uartSelPlr = 1, .ledModePin = 12, .ledModePlr = 1, .ledPwrPin = 14, .ledPwrPlr = 1},  // 2 SLZB-06
     {.btnPin = 33, .btnPlr = 1, .uartSelPin = -1, .uartSelPlr = 0, .ledModePin = -1, .ledModePlr = 0, .ledPwrPin = -1, .ledPwrPlr = 0}, // 3 SLS-classic
     {.btnPin = 14, .btnPlr = 1, .uartSelPin = -1, .uartSelPlr = 0, .ledModePin = -1, .ledModePlr = 0, .ledPwrPin = -1, .ledPwrPlr = 0}, // 4 T-Internet-POE
+    {.btnPin = -1, .btnPlr = 0, .uartSelPin = -1, .uartSelPlr = 0, .ledModePin = -1, .ledModePlr = 0, .ledPwrPin = 13, .ledPwrPlr = 0}, // 5 SmartAll ZgbMix
 };
 
 // Board configurations
@@ -49,4 +52,5 @@ BrdConfigStruct brdConfigs[] = {
     {"CZC-1.0", 2, 0, 1},          // 12
     {"HG POE Plus", 2, 0, 1},      // 13
     {"WGNETZG", 2, 0, 1},          // 14
+    {"SmartAll ZgwMix", 3, 8, 5},     // 15
 };

--- a/src/const/hw.h
+++ b/src/const/hw.h
@@ -46,10 +46,10 @@ struct BrdConfigStruct
     int mistConfigIndex;
 };
 
-#define ETH_CFG_CNT 3
-#define ZB_CFG_CNT 8
-#define MIST_CFG_CNT 5
-#define BOARD_CFG_CNT 14
+#define ETH_CFG_CNT 4
+#define ZB_CFG_CNT 9
+#define MIST_CFG_CNT 6
+#define BOARD_CFG_CNT 16
 
 struct ThisConfigStruct
 {


### PR DESCRIPTION
This PR adds support for the v1.3 board revision (?) of the SmartAll ZgbMix ZigBee gateway device. Pinouts determined by observing PCB traces and probing pins.

Ethernet links up properly, ZigBee radio works as a coordinator. However, the initial hardware probe seems to cause something (ZigBee radio?) to enter a weird state if all previous 15 options are tried without a power cycle, resulting in the probe failing and the hardware config being set to the default. Once the hardware config is set correctly, it boots up fine though.

MCU: ESP32-D0WD-V3
Flash: 16MiB
Ethernet: LAN8720A-based, optionally with PoE (802.3af)
ZigBee hardware: EFR32, CC2652P2, or CC2652P7

Links:
- [Item listing on Taobao](https://item.taobao.com/item.htm?id=626185464430)
- [Vendor wiki for this product](https://wiki.smartall.org/#/zgwmix/infoProduct)
